### PR TITLE
Local folder storage for json files

### DIFF
--- a/add_repo.py
+++ b/add_repo.py
@@ -1,0 +1,21 @@
+from errno import EEXIST
+import logging
+from os import mkdir, path
+
+
+def create_repo(data_path, org_name, repo_name):
+    create_dir(path.join(data_path, org_name))
+    create_dir(path.join(data_path, org_name, repo_name))
+
+
+def create_dir(path):
+    try:
+        mkdir(path)
+    except OSError as exc:
+        if exc.errno != EEXIST:
+            logging.debug('path already exists: %s', path)
+        pass
+
+
+if __name__ == '__main__':
+    create_repo('./data/', 'bsedg', 'events-api')

--- a/scandata.py
+++ b/scandata.py
@@ -1,0 +1,34 @@
+from os import path, scandir
+from typing import List
+
+
+class OrgRepoMap:
+    org: str
+    repos: List[str]
+
+
+def scan_for_orgs(data_path):
+    for org_directory in scandir(data_path):
+        if org_directory.is_dir():
+            yield org_directory.name
+
+
+def scan_for_repos(data_path, org):
+    # org/repo/prs.json
+    for repo_directory in scandir(path.join(data_path, org)):
+        if repo_directory.is_dir():
+            yield repo_directory.name
+
+
+def scan_data(data_path):
+    result = scan_for_orgs(data_path)
+    for org in result:
+        repos = scan_for_repos(data_path, org)
+        print(org)
+        for repo in repos:
+            print(f'   > {repo}')
+
+
+if __name__ == "__main__":
+    data_path = './data/'
+    scan_data(data_path)


### PR DESCRIPTION
`add_repo.py` file adds simple utility to basically use `mkdir -p` for a pattern like: `{DATA_DIR}` / `{ORG}` / `{REPO}`.

`scandata.py` file scans the existing `{DATA_DIR}` for all `orgs` and `repos` that already exist.

fixes #2 